### PR TITLE
Major update to QC & changes for run 2024_1_1.1_GRCh38

### DIFF
--- a/Variant_Catalogue_v1.sh
+++ b/Variant_Catalogue_v1.sh
@@ -5,7 +5,7 @@
 #SBATCH --ntasks-per-node=1
 #SBATCH --mem=4G
 #SBATCH -p silent_q 
-#SBATCH --mail-user=kiana.rashidi@bcchr.ca
+#SBATCH --mail-user=
 #SBATCH --mail-type=ALL
 
 ## Output and Stderr

--- a/modules/Hail_sample_QC.nf
+++ b/modules/Hail_sample_QC.nf
@@ -30,14 +30,14 @@ process Hail_sample_QC {
 	path '*.txt'
 
 	script:
-	if (params.filter_sample == False)
+	if (!params.filter_samples)
 		"""
 			#!/usr/bin/env python ../../../modules/Hail_sample_QC.py $SNV_vcf $params.tmp_dir $assembly $ref $ref_index
 		"""
-	else if (params.filter_sample == True)
+	else if (params.filter_samples)
 		"""
 			#!/usr/bin/env python ../../../modules/Hail_sample_QC.py $SNV_vcf $params.tmp_dir $assembly $ref $ref_index $params.filter_list
 		"""
 	else
-	 error "Invalid filter_sample parameter, must be True or False"
+	 error "Invalid filter_sample parameter, must be true or false"
 }

--- a/modules/Hail_sample_QC.nf
+++ b/modules/Hail_sample_QC.nf
@@ -10,6 +10,8 @@
 process Hail_sample_QC {
 
 	publishDir "$params.outdir_ind/${assembly}/${batch}/${run}/QC/Aggregated/Hail/Samples/", mode: 'copy', pattern : '*.html'
+	publishDir "$params.outdir_ind/${assembly}/${batch}/${run}/QC/Aggregated/Hail/Samples/", mode: 'copy', pattern : '*.txt'
+	publishDir "$params.outdir_ind/${assembly}/${batch}/${run}/QC/Aggregated/Hail/Samples/", mode: 'copy', pattern : '*.tsv'
 	publishDir "$params.outdir_ind/${assembly}/${batch}/${run}/vcf_post_hail/", mode: 'copy', pattern : '*filtered_samples.vcf.bgz'
 
 	input :
@@ -24,9 +26,18 @@ process Hail_sample_QC {
 	path '*.html', emit : graph
 	path '*filtered_samples.vcf.bgz', emit : vcf_sample_filtered
 	path '*filtered_samples_sex.tsv', emit : filtered_sample_sex
+	path '*samples_sex_f_stat.tsv'
+	path '*.txt'
 
 	script:
-	"""
-        #!/usr/bin/env python ../../../modules/Hail_sample_QC.py $SNV_vcf $params.tmp_dir $assembly $ref $ref_index
-	"""
+	if (params.filter_sample == False)
+		"""
+			#!/usr/bin/env python ../../../modules/Hail_sample_QC.py $SNV_vcf $params.tmp_dir $assembly $ref $ref_index
+		"""
+	else if (params.filter_sample == True)
+		"""
+			#!/usr/bin/env python ../../../modules/Hail_sample_QC.py $SNV_vcf $params.tmp_dir $assembly $ref $ref_index $params.filter_list
+		"""
+	else
+	 error "Invalid filter_sample parameter, must be True or False"
 }

--- a/modules/Hail_sample_QC.py
+++ b/modules/Hail_sample_QC.py
@@ -44,9 +44,11 @@ genome=sys.argv[3] #either GRCh37 or GRCh38 (params.assembly)
 ref_fasta=sys.argv[4]
 ref_fasta_index=sys.argv[5]
 pop_vcf = sys.argv[1]
+filter_samples = False #default is false (flag for filtering samples)
 
 #use filter list only when it is passed as argument
-if ((len(sys.argv)-1) == 6):
+#counts extra arg with env 
+if ((len(sys.argv)-1) == 7):
     filter_samples = True # flag for running filter step
     filter_table = sys.argv[6]
 

--- a/modules/Hail_sample_QC.py
+++ b/modules/Hail_sample_QC.py
@@ -1,38 +1,55 @@
 #!/usr/bin/env python
 # coding: utf-8
 
+# In[1]:
+
+
 # Hail and plot initialisation
 
-# Last Updated: June 1, 2024 - Stephanie Petrone
-#   Update: fixing issue with contig naming discrepency for GRCh38 files 
-#   and Hail's expected labeling conventions ('chr' prefix for GRCh38)
-# In[91]:
 
+# In[1]:
+
+
+temp_directory="./tmp"
 import sys
-temp_directory=sys.argv[2]
-genome=sys.argv[3] #either GRCh37 or GRCh38 (params.assembly)
-ref_fasta=sys.argv[4]
-ref_fasta_index=sys.argv[5]
-
 import hail as hl
 from hail.plot import output_notebook, show
-hl.init(tmp_dir=temp_directory)
-output_notebook()
-
-
-# In[ ]:
-
-
-from hail.plot import show
 from pprint import pprint
 from bokeh.models import Span
 hl.plot.output_notebook()
 from bokeh.models import Range1d
 from bokeh.plotting import figure, output_file, show, save
 from bokeh.io import export_png
-
 import pandas as pd
 import os
+
+# Hail and plot initialisation
+# Configure Spark properties
+spark_conf = {
+    'spark.driver.memory': '8g'  # Set the driver memory, e.g., to 8 GB
+}
+
+# Initialize Hail with custom Spark configuration
+hl.init(master='local[*]', spark_conf=spark_conf, tmp_dir=temp_directory)
+
+output_notebook()
+
+
+# In[41]:
+
+
+
+temp_directory=sys.argv[2]
+genome=sys.argv[3] #either GRCh37 or GRCh38 (params.assembly)
+ref_fasta=sys.argv[4]
+ref_fasta_index=sys.argv[5]
+pop_vcf = sys.argv[1]
+
+#use filter list only when it is passed as argument
+if ((len(sys.argv)-1) == 6):
+    filter_samples = True # flag for running filter step
+    filter_table = sys.argv[6]
+
 
 
 # Import a vcf file and read it as a matrix table (mt, hail specific file type)
@@ -41,18 +58,18 @@ import os
 # for different contig labeling and Hail's requirements
 # (Hail requires GRCh37 to have no 'chr' prefix and GRCh38 to use it
 if genome == 'GRCh37':
-    hl.import_vcf(sys.argv[1],
+    hl.import_vcf(pop_vcf,
         array_elements_required=False, 
         force_bgz=True, 
         reference_genome=genome).write('SNV_vcf.mt', overwrite=True)
 
 elif genome == 'GRCh38':
     # add extra re-coding step, as reference genome and vcf files
-    # for GRCh38 data are using GRCh37 labelling (no 'chr' prefix)
+    # for GRCh38 data are using ensemble labelling (no 'chr' prefix)
     # and Hail requires that they use the 'chr' prefix
     recode = {"MT":"chrM", **{f"{i}":f"chr{i}" for i in (list(range(1, 23)) + ['X', 'Y'])}} 
 
-    hl.import_vcf(sys.argv[1], 
+    hl.import_vcf(pop_vcf, 
         array_elements_required=False, 
         force_bgz=True, 
         reference_genome=genome,
@@ -61,7 +78,8 @@ elif genome == 'GRCh38':
 else:
     raise Exception("Must use GRCh37 or GRCh38 assembly!")
 
-# In[ ]:
+
+# In[141]:
 
 
 mt = hl.read_matrix_table('SNV_vcf.mt')
@@ -74,7 +92,8 @@ mt = hl.read_matrix_table('SNV_vcf.mt')
 # - plot_histo : To create the histogram as expected
 # - plot_sp : To create the scatter plots as expected
 
-# In[ ]:
+
+# In[142]:
 
 
 def stat(table):
@@ -87,7 +106,7 @@ def stat(table):
     return Mean, StdDev, Low_threashold, High_threashold, min_graph, max_graph
 
 
-# In[106]:
+# In[143]:
 
 
 def plot_histo (table_plot, mt_plot, variable) :
@@ -105,7 +124,7 @@ def plot_histo (table_plot, mt_plot, variable) :
     return save(p)
 
 
-# In[107]:
+# In[6]:
 
 
 def plot_sp (table_x_axis, mt_x_axis, table_y_axis, mt_y_axis, x_variable, y_variable) :
@@ -132,7 +151,8 @@ def plot_sp (table_x_axis, mt_x_axis, table_y_axis, mt_y_axis, x_variable, y_var
 
 # **Generate the sample quality control metrics using hail**
 
-# In[ ]:
+
+# In[144]:
 
 
 mt = hl.sample_qc(mt)
@@ -165,7 +185,8 @@ mt = hl.sample_qc(mt)
 
 # Save the values as table
 
-# In[ ]:
+
+# In[145]:
 
 
 mt.sample_qc.dp_stats.mean.export('DP.tsv')
@@ -185,7 +206,8 @@ mt.sample_qc.n_transversion.export('n_transversion.tsv')
 
 # Open the tables as data frame
 
-# In[ ]:
+
+# In[146]:
 
 
 DP_table=pd.read_table('DP.tsv')
@@ -206,7 +228,8 @@ n_transversion_table=pd.read_table('n_transversion.tsv')
 
 # Rename the column of the tables
 
-# In[ ]:
+
+# In[147]:
 
 
 DP_table.rename(columns = {DP_table.columns[1]:'DP'}, inplace = True)
@@ -227,13 +250,14 @@ n_transversion_table.rename(columns = {n_transversion_table.columns[1]:'n_transv
 
 # Create the graphs
 
-# In[108]:
+
+# In[148]:
 
 
 plot_histo(DP_table, mt.sample_qc.dp_stats.mean, 'Mean Depth per sample')
 
 
-# In[109]:
+# In[149]:
 
 
 plot_histo(GQ_table,
@@ -241,7 +265,7 @@ plot_histo(GQ_table,
            'Mean Genotype quality per sample')
 
 
-# In[110]:
+# In[150]:
 
 
 plot_histo(call_rate_table,
@@ -249,7 +273,7 @@ plot_histo(call_rate_table,
            'Call Rate per sample')
 
 
-# In[111]:
+# In[151]:
 
 
 plot_histo(r_het_hom_var_table,
@@ -257,7 +281,7 @@ plot_histo(r_het_hom_var_table,
            'Ratio heterozygous to homozygous variants per sample')
 
 
-# In[112]:
+# In[152]:
 
 
 plot_sp (n_het_table,
@@ -268,7 +292,7 @@ plot_sp (n_het_table,
          'Number of homozygous variants')
 
 
-# In[113]:
+# In[153]:
 
 
 plot_histo(n_snp_table,
@@ -276,7 +300,7 @@ plot_histo(n_snp_table,
            'Number of SNPs per sample')
 
 
-# In[115]:
+# In[154]:
 
 
 plot_histo(n_singleton_table,
@@ -284,7 +308,7 @@ plot_histo(n_singleton_table,
            'Number of singletons per sample')
 
 
-# In[116]:
+# In[155]:
 
 
 plot_sp (n_insertion_table,
@@ -295,7 +319,7 @@ plot_sp (n_insertion_table,
          'Number of deletions')
 
 
-# In[117]:
+# In[156]:
 
 
 plot_histo(r_insertion_deletion_table,
@@ -303,7 +327,7 @@ plot_histo(r_insertion_deletion_table,
            'Ratio insertions to deletions per sample')
 
 
-# In[118]:
+# In[157]:
 
 
 plot_sp (n_transition_table,
@@ -314,7 +338,7 @@ plot_sp (n_transition_table,
          'Number of transversions')
 
 
-# In[119]:
+# In[158]:
 
 
 plot_histo(r_ti_tv_table,
@@ -332,11 +356,13 @@ plot_histo(r_ti_tv_table,
 
 
 
+# In[160]:
 
-
-# **Filter the samples based on the threasholds repersented on the figures**
-# 
-# On the test with 11 samples, no samples shoould be removed
+# **Flag the samples based on the threasholds repersented on the figures**
+# (this was previously used as an automatic filter, but it was quite
+# arbitrarily filtering good samples). Instead, manually look at the flagged
+# samples.
+# (originally Solenne's code)
 # 
 # Low_threashold = Mean - 3*StdDev = stat(table) [2]
 # 
@@ -352,45 +378,23 @@ plot_histo(r_ti_tv_table,
 # - ?? Ratio insertions to deletion per sample lower than the low threshoold or higher than high threshold
 # - Ratio transition to transversions per sample lower than the low threshoold or higher than high threshold
 
-# In[120]:
 
+# Return a list of flagged samples and number
 
-filtered_mt = mt.filter_cols(
-    (stat(DP_table) [3] > mt.sample_qc.dp_stats.mean)  &
-    (mt.sample_qc.dp_stats.mean > stat(DP_table) [2]) &
-    (stat(GQ_table) [3] > mt.sample_qc.gq_stats.mean) &
-    (mt.sample_qc.gq_stats.mean > stat(GQ_table) [2]) &
-    (stat(call_rate_table) [3] > mt.sample_qc.call_rate) &
-    (mt.sample_qc.call_rate > stat(call_rate_table) [2]) &
-    (stat(r_het_hom_var_table) [3] > mt.sample_qc.r_het_hom_var) &
-    (mt.sample_qc.r_het_hom_var > stat(r_het_hom_var_table) [2]) &
-    (stat(n_snp_table) [3] > mt.sample_qc.n_snp) &
-    (mt.sample_qc.n_snp > stat(n_snp_table) [2]) &
-    (stat(n_singleton_table) [3] > mt.sample_qc.n_singleton) &
-    (mt.sample_qc.n_singleton > stat(n_singleton_table) [2]) &
-    (stat(r_insertion_deletion_table) [3] > mt.sample_qc.r_insertion_deletion) &
-    (mt.sample_qc.r_insertion_deletion > stat(r_insertion_deletion_table) [2]) &
-    (stat(r_ti_tv_table) [3] > mt.sample_qc.r_ti_tv) &
-    (mt.sample_qc.r_ti_tv> stat(r_ti_tv_table) [2])
-)
-
-
-# In[124]:
-
-hl.export_vcf(filtered_mt, 'filtered_samples.vcf.bgz', tabix = True)
-
-# Write the report of the number of filtered out samples and the reason they were filtered out
-
-def calc_removed_samples(mt, mt_var, stat_table) :
+def calc_flagged_samples(mt, mt_var, stat_table) :
     # Save sample genotype quality metrics information to separate file
     input_mt = mt.annotate_cols(
         keep=(mt_var > stat_table [2]) &
             (mt_var < stat_table [3])
     )
 
-    n_removed = input_mt.aggregate_cols(hl.agg.count_where(~input_mt.keep))
+    flagged = input_mt.filter_cols(input_mt.keep == False, keep=True)
+    flagged_samples = flagged.s.collect()
     
-    return n_removed
+    return flagged_samples
+
+
+# In[161]:
 
 
 def report_stats():
@@ -400,33 +404,79 @@ def report_stats():
     out_stats = hl.hadoop_open(f"sample_QC.txt", "w")
     # Report numbers of filtered samples
     out_stats.write(
-        f"Number of samples removed because of depth metrics: {DP_removed}\n"
-        f"Number of samples removed because of genotype quality metrics: {GQ_removed}\n"
-        f"Number of samples removed because of call rate metrics: {CR_removed}\n"
-        f"Number of samples removed because of ratio heterozygous over homozygous: {r_het_hom_removed}\n"
-        f"Number of samples removed because of number of snps: {n_snps_removed}\n"
-        f"Number of samples removed because of number of singletons: {n_singletons_removed}\n"
-        f"Number of samples removed because of ratio insertions over deletions: {r_ins_del_removed}\n"
-        f"Number of samples removed because of ratio transversions / transitions: {r_ti_tv_removed}\n"
-        f"Percentage of the samples filtered out: {perc_removed_samples}\n"
+        f"Samples flagged because of depth metrics: {DP_flagged}\n"
+        f"Count: {DP_count}\n\n"
+
+        f"Samples flagged because of genotype quality metrics: {GQ_flagged}\n"
+        f"Count: {GQ_count}\n\n"
+
+        f"Samples flagged because of call rate metrics: {CR_flagged}\n"
+        f"Count: {CR_count}\n\n"
+
+        f"Samples flagged because of ratio heterozygous over homozygous: {r_het_hom_flagged}\n"
+        f"Count: {r_het_hom_count}\n\n"
+
+        f"Samples flagged because of number of snps: {n_snps_flagged}\n"
+        f"Count: {n_snps_count}\n\n"
+
+        f"Samples flagged because of number of singletons: {n_singletons_flagged}\n"
+        f"Count: {n_singleton_count}\n\n"
+
+        f"Samples flagged because of ratio insertions over deletions: {r_ins_del_flagged}\n"
+        f"Count: {r_ins_del_count}\n\n"
+
+        f"Samples flagged because of ratio transversions / transitions: {r_ti_tv_flagged}\n"
+        f"Count: {r_ti_tv_count}\n\n"
+
+        f"All samples flagged: {all_samples_flagged}\n"
+        f"Count of the samples flagged: {count_flagged_samples}\n"
     )
     out_stats.close()
 
 
-DP_removed = calc_removed_samples(mt, mt.sample_qc.dp_stats.mean, stat(DP_table))
-GQ_removed = calc_removed_samples(mt, mt.sample_qc.gq_stats.mean, stat(GQ_table))
-CR_removed = calc_removed_samples(mt, mt.sample_qc.call_rate, stat(call_rate_table))
-r_het_hom_removed = calc_removed_samples(mt, mt.sample_qc.r_het_hom_var, stat(r_het_hom_var_table))
-n_snps_removed = calc_removed_samples(mt, mt.sample_qc.n_snp, stat(n_snp_table))
-n_singletons_removed = calc_removed_samples(mt, mt.sample_qc.n_singleton, stat(n_singleton_table))
-r_ins_del_removed = calc_removed_samples(mt, mt.sample_qc.r_insertion_deletion, stat(r_insertion_deletion_table))
-r_ti_tv_removed = calc_removed_samples(mt, mt.sample_qc.r_ti_tv, stat(r_ti_tv_table))
-perc_removed_samples = (mt.count()[0]-filtered_mt.count()[0])/mt.count()[0] * 100
+
+
+# In[162]:
+
+
+DP_flagged = calc_flagged_samples(mt, mt.sample_qc.dp_stats.mean, stat(DP_table))
+DP_count = len(DP_flagged)
+
+GQ_flagged = calc_flagged_samples(mt, mt.sample_qc.gq_stats.mean, stat(GQ_table))
+GQ_count = len(GQ_flagged)
+
+CR_flagged = calc_flagged_samples(mt, mt.sample_qc.call_rate, stat(call_rate_table))
+CR_count = len(CR_flagged)
+
+r_het_hom_flagged = calc_flagged_samples(mt, mt.sample_qc.r_het_hom_var, stat(r_het_hom_var_table))
+r_het_hom_count = len(r_het_hom_flagged)
+
+n_snps_flagged = calc_flagged_samples(mt, mt.sample_qc.n_snp, stat(n_snp_table))
+n_snps_count = len(n_snps_flagged)
+
+n_singletons_flagged = calc_flagged_samples(mt, mt.sample_qc.n_singleton, stat(n_singleton_table))
+n_singleton_count = len(n_singletons_flagged)
+
+r_ins_del_flagged = calc_flagged_samples(mt, mt.sample_qc.r_insertion_deletion, stat(r_insertion_deletion_table))
+r_ins_del_count = len(r_ins_del_flagged)
+
+r_ti_tv_flagged = calc_flagged_samples(mt, mt.sample_qc.r_ti_tv, stat(r_ti_tv_table))
+r_ti_tv_count = len(r_ti_tv_flagged)
+
+all_samples_flagged =  list(set(DP_flagged + GQ_flagged + CR_flagged + r_het_hom_flagged + n_snps_flagged + n_singletons_flagged +
+                              r_ins_del_flagged + r_ti_tv_flagged))
+
+count_flagged_samples = len(all_samples_flagged)
 
 report_stats()
 
 
-# Impute sex based on F-stat (only for sample who passed QC)
+
+
+# In[163]:
+
+
+# Impute sex based on F-stat - for all samples
 
 # Using gnomAD hard filters :
 #- Ambiguous sex: fell outside of:
@@ -434,7 +484,7 @@ report_stats()
 #- XX: F-stat < 0.5 - this value is determined by visually
 #                     looking at the distribution
 
-imputed_sex_filtered_samples = hl.impute_sex(filtered_mt.GT)
+imputed_sex_filtered_samples = hl.impute_sex(mt.GT)
 imputed_sex_filtered_samples = imputed_sex_filtered_samples.annotate(
         sex=hl.if_else(imputed_sex_filtered_samples.f_stat < 0.5,
                        "XX",
@@ -443,6 +493,9 @@ imputed_sex_filtered_samples = imputed_sex_filtered_samples.annotate(
         )
 filtered_samples_sex=imputed_sex_filtered_samples.select("sex")
 filtered_samples_sex.export('filtered_samples_sex.tsv')
+
+filtered_samples_sex_fstat=imputed_sex_filtered_samples.select("sex", "f_stat")
+filtered_samples_sex_fstat.export('filtered_samples_sex_f_stat.tsv')
 
 
 
@@ -456,3 +509,64 @@ pl.add_layout(annot)
 
 output_file(filename=("impute_sex_distribution.html"))
 save(pl)
+
+
+
+
+# In[164]:
+
+
+#-----------------------FILTER STEP-----------------------------------
+# Filter samples if flag set (optional)
+# -The filter table should be a single column table containing
+# the sample IDs
+#---------------------------------------------------------------------
+
+if (filter_samples):
+    # important! - hail's filter_cols does not update the info fields in the
+    # row fields in the matrix table. These must be updated manually.
+    
+    #get a list from the table
+    try:
+        df = pd.read_csv(filter_table, sep='\t')
+
+    except Exception as e:
+        print(f"An error occurred opening the sample filter table: {e}")
+    
+    
+    #Filter samples - remove any that are in the list provided
+    filter_list = df['s'].tolist()
+    filter_count = len(filter_list)
+    mt = mt.filter_cols(hl.literal(filter_list).contains(mt.s), keep=False)
+    
+
+    out_filtered = hl.hadoop_open(f"samples_filtered.txt", "w")
+    
+    # Report numbers of filtered samples
+    out_filtered.write(
+            f"Samples filtered: {filter_list}\n"
+            f"Count of samples filtered: {filter_count}\n"
+        )
+    out_filtered.close()
+
+
+# In[168]:
+
+
+#hail's filter_cols function does not adjust info fields, to adjust info fields, use the code below
+# note that this is re-calculate during the next step (hail_variant_qc) during stratification
+# mt = hl.variant_qc(mt)
+# mt = mt.annotate_rows(info = mt.info.annotate(AC=mt.variant_qc.AC)) 
+# mt = mt.annotate_rows(info = mt.info.annotate(AN=mt.variant_qc.AN)) 
+# mt = mt.annotate_rows(info = mt.info.annotate(AF=mt.variant_qc.AF)) 
+
+
+# In[169]:
+
+
+#export file
+hl.export_vcf(mt, 'filtered_samples.vcf.bgz', tabix = True)
+
+
+# In[ ]:
+

--- a/modules/Hail_variant_QC.nf
+++ b/modules/Hail_variant_QC.nf
@@ -11,11 +11,11 @@
 process Hail_variant_QC {
         //  maxForks 1
         publishDir "$params.outdir_ind/${assembly}/${batch}/${run}/QC/Aggregated/Hail/Variants/SNV/", mode: 'copy', pattern : '*.html'
-        publishDir "$params.outdir_ind/${assembly}/${batch}/${run}/QC/Aggregated/Hail/Variants/SNV/", mode: 'copy', pattern : 'SNV_indel_QC_report.txt'
+        publishDir "$params.outdir_ind/${assembly}/${batch}/${run}/QC/Aggregated/Hail/Variants/SNV/reports/", mode: 'copy', pattern : '*.txt'
         publishDir "$params.outdir_ind/${assembly}/${batch}/${run}/vcf_post_hail/", mode: 'copy', pattern : 'SNV_filtered_with_geno*'
         publishDir "$params.outdir_pop/${assembly}/${run}/SNV/Vcf_pre_annotation/", mode: 'copy', pattern : 'SNV_filtered_frequ_only*'
-		publishDir "$params.outdir_pop/${assembly}/${run}/SNV/Vcf_pre_annotation/large_indels/", mode: 'copy', pattern : 'SNV_large_indels*'
-		publishDir "$params.outdir_pop/${assembly}/${run}/SNV/Vcf_pre_annotation/autosomal/", mode: 'copy', pattern : 'SNV_autosomal.vcf*'
+		publishDir "$params.outdir_ind/${assembly}/${batch}/${run}/vcf_post_hail/large_indels/", mode: 'copy', pattern : 'SNV_large_indels*'
+		publishDir "$params.outdir_ind/${assembly}/${batch}/${run}/vcf_post_hail/autosomal/", mode: 'copy', pattern : 'SNV_autosomal.vcf*'
 
 	input :
 	file vcf_sample_filtered

--- a/modules/Hail_variant_QC.nf
+++ b/modules/Hail_variant_QC.nf
@@ -14,6 +14,8 @@ process Hail_variant_QC {
         publishDir "$params.outdir_ind/${assembly}/${batch}/${run}/QC/Aggregated/Hail/Variants/SNV/", mode: 'copy', pattern : 'SNV_indel_QC_report.txt'
         publishDir "$params.outdir_ind/${assembly}/${batch}/${run}/vcf_post_hail/", mode: 'copy', pattern : 'SNV_filtered_with_geno*'
         publishDir "$params.outdir_pop/${assembly}/${run}/SNV/Vcf_pre_annotation/", mode: 'copy', pattern : 'SNV_filtered_frequ_only*'
+		publishDir "$params.outdir_pop/${assembly}/${run}/SNV/Vcf_pre_annotation/large_indels/", mode: 'copy', pattern : 'SNV_large_indels*'
+		publishDir "$params.outdir_pop/${assembly}/${run}/SNV/Vcf_pre_annotation/autosomal/", mode: 'copy', pattern : 'SNV_autosomal.vcf*'
 
 	input :
 	file vcf_sample_filtered
@@ -23,7 +25,7 @@ process Hail_variant_QC {
 	val ref_index
 	val batch
 	val run
-	each chr
+	each var_qc_interval
 
 	output :
 	path '*.html', emit : graph
@@ -33,9 +35,12 @@ process Hail_variant_QC {
     path 'SNV_filtered_frequ_only*.vcf.bgz', emit : vcf_SNV_filtered_frequ_only
     path 'SNV_filtered_frequ_only*.vcf.bgz.tbi', emit : index_SNV_filtered_frequ_only
 
+	path 'SNV_large_indels*.vcf*'
+	path 'SNV_autosomal.vcf*'
+
 	script:
 	"""
-        #!/usr/bin/env python ../../../modules/Hail_variant_QC.py $vcf_sample_filtered $sample_sex_file $params.tmp_dir $assembly $ref $ref_index $chr
+        #!/usr/bin/env python ../../../modules/Hail_variant_QC.py $vcf_sample_filtered $sample_sex_file $params.tmp_dir $assembly $ref $ref_index $var_qc_interval
 	"""
 }
 

--- a/modules/Hail_variant_QC.nf
+++ b/modules/Hail_variant_QC.nf
@@ -9,7 +9,7 @@
 // Future update : Include gnomAD frequency to each varaint, annotate the varaints using vep
 
 process Hail_variant_QC {
-          maxForks 1
+        //  maxForks 1
         publishDir "$params.outdir_ind/${assembly}/${batch}/${run}/QC/Aggregated/Hail/Variants/SNV/", mode: 'copy', pattern : '*.html'
         publishDir "$params.outdir_ind/${assembly}/${batch}/${run}/QC/Aggregated/Hail/Variants/SNV/", mode: 'copy', pattern : 'SNV_indel_QC_report.txt'
         publishDir "$params.outdir_ind/${assembly}/${batch}/${run}/vcf_post_hail/", mode: 'copy', pattern : 'SNV_filtered_with_geno*'
@@ -29,14 +29,14 @@ process Hail_variant_QC {
 
 	output :
 	path '*.html', emit : graph
-	path 'SNV_indel_QC_report.txt', emit : SNV_QC_report
+	path 'SNV_variant_QC_report*.txt', emit : SNV_QC_report
 
 	path 'SNV_filtered_with_geno*.vcf.bgz*', emit : SNV_filtered_with_geno
     path 'SNV_filtered_frequ_only*.vcf.bgz', emit : vcf_SNV_filtered_frequ_only
     path 'SNV_filtered_frequ_only*.vcf.bgz.tbi', emit : index_SNV_filtered_frequ_only
 
 	path 'SNV_large_indels*.vcf*'
-	path 'SNV_autosomal.vcf*'
+	path '*.vcf*'
 
 	script:
 	"""

--- a/modules/Hail_variant_QC.py
+++ b/modules/Hail_variant_QC.py
@@ -672,7 +672,7 @@ out_stats.write(
 
         f"\n------------------------------------------------------------\n"
         f"\nSUMMARY\n"
-        f"\n (whole dataset)\n"
+        f"\n\n"
         f"------------------------------------------------------------\n"
         f"\nTotal sites before filtering: {count_rows_before_indel_filter}\n"
         f"\nTotal called genotypes (before filters): {count_GT_before_indel_filter}\n\n\n"

--- a/modules/Hail_variant_QC.py
+++ b/modules/Hail_variant_QC.py
@@ -183,8 +183,11 @@ def stat(table):
 
 def plot_histo (table_plot, mt_plot, variable) :
     output_file(filename=os.path.join(("variant_QC_"+variable+".html")), title=f"Variant QC HTML file {chr}")
+    range = (stat(table_plot) [4], stat(table_plot) [5])
+    if ((stat(table_plot) [5] - stat(table_plot) [4]) <= 0 ):
+        range = (0,1)
     p = hl.plot.histogram(mt_plot,
-                      range = (stat(table_plot) [4], stat(table_plot) [5]),
+                      range,
                       bins = 60,
                       legend=variable,
                       title="Red lines are Mean +/- 3xStdDev")
@@ -781,8 +784,8 @@ if(chr == "autosomal"):
         hl.export_vcf(contig_mt_no_geno, f'SNV_filtered_frequ_only_{c}.vcf.bgz',tabix=True)
 
 else:
-    hl.export_vcf(SNV_mt_var_filtered, f'SNV_filtered_with_geno_{chr}.vcf.bgz', tabix=True)
-    hl.export_vcf(SNV_mt_var_filtered_no_geno, f'SNV_filtered_frequ_only_{chr}.vcf.bgz',
+    hl.export_vcf(SNV_mt_var_filtered, f'SNV_filtered_with_geno_{contigs}.vcf.bgz', tabix=True)
+    hl.export_vcf(SNV_mt_var_filtered_no_geno, f'SNV_filtered_frequ_only_{contigs}.vcf.bgz',
      tabix=True)
 
 

--- a/modules/SNV_data_organization.R
+++ b/modules/SNV_data_organization.R
@@ -267,10 +267,17 @@ write.table(table_variant_severities_noNA, file=paste0("variants_consequences_",
 show("varaint consequence ok")
 
 #Variants_annotation
+# Function to decode the "%3D" character
+decode_hgvsp <- function(df) {
+  df$hgvsp <- gsub("%3D", "=", df$hgvsp)
+  return(df)
+}
+
 #variants_transcript_id, hgvsp, polyphen, sift (for polyphen and sift, score and interpretation together)
 table_variant_annotation =cbind(All_info$HGVSp, All_info$SIFT, All_info$PolyPhen, All_info$Feature, All_info$variant)
 colnames(table_variant_annotation) = c("hgvsp", "sift", "polyphen", "transcript", "variant")
 table_variant_annotation = as.data.frame(table_variant_annotation)
+table_variant_annotation <- decode_hgvsp(table_variant_annotation)
 table_variant_annotation_noNA = table_variant_annotation[!grepl("NA",table_variant_annotation$hgvsp), ]
 table_variant_annotation_noNA = unique(table_variant_annotation_noNA)
 write.table(table_variant_annotation_noNA, file=paste0("variants_annotations_", chromosome,".tsv"), quote=FALSE, row.names = FALSE, sep="\t")
@@ -303,11 +310,7 @@ show("gnomad frequ ok")
 # Short name, (NCBI gene Id, may not be necessary anymore)
 gene_table=as.data.frame(unique(All_info$SYMBOL))
 colnames(gene_table)=c("short_name")
-gene_table = as.data.frame(gene_table)
-gene_table_noNA = gene_table[!grepl("NA", gene_table$short_name),]
-gene_table_noNA = unique(gene_table_noNA)
-gene_table_noNA = as.data.frame(gene_table_noNA)
-colnames(gene_table_noNA)=c("short_name")
+gene_table_noNA = gene_table %>% filter(!is.na(short_name)) %>% filter(short_name != "") %>% unique()
 write.table(gene_table_noNA, file=paste0("genes_", chromosome, ".tsv"), quote=FALSE, row.names = FALSE, sep="\t")
 
 show("gene table ok")
@@ -319,7 +322,7 @@ show("gene table ok")
 transcript_table=as.data.frame(unique(cbind(All_info$Feature, All_info$SYMBOL, All_info$SOURCE, All_info$TSL)))
 colnames(transcript_table)=c("transcript_id", "gene", "transcript_type", "tsl")
 transcript_table=transcript_table %>% mutate(transcript_type = str_replace(transcript_type, "Ensembl", "E"))
-transcript_table=transcript_table %>% mutate(transcript_type = str_replace(transcript_type, "Refseq", "R"))
+transcript_table=transcript_table %>% mutate(transcript_type = str_replace(transcript_type, "RefSeq", "R"))
 transcript_table = unique(transcript_table)
 transcript_table = as.data.frame(transcript_table)
 transcript_table_noNA = transcript_table[!grepl("NA", transcript_table$transcript_id),]

--- a/modules/SNV_data_organization.R
+++ b/modules/SNV_data_organization.R
@@ -43,7 +43,7 @@ if (assembly == "GRCh37" && chr == "Y") {
   	gnomad_file = fread(gfile)
 
 }
-if (length(gnomad_file)>11)gnomad_file[,12]=NULL
+if (length(gnomad_file)>14)gnomad_file[,15]=NULL
 #names(gnomad_file)
 #head(gnomad_file)
 #Create the variant ID (chr-Pos_ref_alt)
@@ -297,10 +297,16 @@ show("variant ok")
 #Extract only the variant that are present in the IBVL
 #gnomad_intersect = gnomad_file[gnomad_file$ID_db_gnomad  %in%  SNV_vcf@fix[,c("ID")], ]
 gnomad_intersect = gnomad_file[gnomad_file$ID_db_gnomad  %in%  All_info$variant, ]
-#Keep only the wanted info
-gnomad_intersect_mini=gnomad_intersect[,c("ID_db_gnomad", "AF", "AC", "AN", "nhomalt")]
-#rename the columns as expected in the SQL
-colnames(gnomad_intersect_mini)=c("variant", "af_tot", "ac_tot", "an_tot", "hom_tot")
+#Keep only the wanted info, #incorporate additional filter columns in newer gnomad versions
+if (assembly == "GRCh37") {
+	gnomad_intersect_mini=gnomad_intersect[,c("ID_db_gnomad", "AF", "AC", "AN", "nhomalt", "FILTER")]
+	#rename the columns as expected in the SQL
+	colnames(gnomad_intersect_mini)=c("variant", "af_tot", "ac_tot", "an_tot", "hom_tot", "FILTER")
+} else if (assembly =="GRCh38") {
+	gnomad_intersect_mini=gnomad_intersect[,c("ID_db_gnomad", "AF", "AC", "AN", "nhomalt", "FILTER", "exomes_filters", "genomes_filters")]
+	#rename the columns as expected in the SQL
+	colnames(gnomad_intersect_mini)=c("variant", "af_tot", "ac_tot", "an_tot", "hom_tot", "FILTER", "exomes_filters", "genomes_filters")
+}
 gnomad_intersect_mini = unique(gnomad_intersect_mini)
 write.table(gnomad_intersect_mini, file=paste0("genomic_gnomad_frequencies_", chromosome, ".tsv"), quote=FALSE, row.names = FALSE, sep="\t")
 

--- a/modules/SNV_data_organization.nf
+++ b/modules/SNV_data_organization.nf
@@ -17,8 +17,10 @@ process SNV_data_organization {
         publishDir "$params.outdir_pop/${assembly}/${run}/Oracle_table/variants_transcripts/", mode: 'copy', pattern: "variants_transcripts_*"
         publishDir "$params.outdir_pop/${assembly}/${run}/Oracle_table/variants_consequences/", mode: 'copy', pattern: "variants_consequences_*"
         publishDir "$params.outdir_pop/${assembly}/${run}/Oracle_table/variants_annotations/", mode: 'copy', pattern: "variants_annotations_*"
-        publishDir "$params.outdir_pop/${assembly}/${run}/Oracle_table/variants/", mode: 'copy', pattern: "variants_[A-Z0-9].tsv"
-	publishDir "$params.outdir_pop/${assembly}/${run}/Oracle_table/variants/", mode: 'copy', pattern: "variants_[A-Z0-9][A-Z0-9].tsv"
+        publishDir "$params.outdir_pop/${assembly}/${run}/Oracle_table/variants/", mode: 'copy', pattern: "variants_chr[A-Z0-9].tsv"
+		publishDir "$params.outdir_pop/${assembly}/${run}/Oracle_table/variants/", mode: 'copy', pattern: "variants_chr[A-Z0-9][A-Z0-9].tsv"
+		publishDir "$params.outdir_pop/${assembly}/${run}/Oracle_table/variants/", mode: 'copy', pattern: "variants_[A-Z0-9].tsv"
+		publishDir "$params.outdir_pop/${assembly}/${run}/Oracle_table/variants/", mode: 'copy', pattern: "variants_[A-Z0-9][A-Z0-9].tsv"
 
 	input :
 	path gnomad_SNV_frequ

--- a/modules/annotation_table_merged.nf
+++ b/modules/annotation_table_merged.nf
@@ -17,7 +17,6 @@ process annotation_table_merged {
 
         input :
         file vcf
-		file index
 		val vep_cache_merged
 		val vep_cache_merged_version
 		val assembly

--- a/modules/bcf_to_vcf.nf
+++ b/modules/bcf_to_vcf.nf
@@ -31,7 +31,7 @@ process bcf_to_vcf {
 	bcftools index -t ${bcf_file.simpleName}_GLnexus_output.vcf.gz
 
 	# normalize/left align and split multi-allelic variants 
-	bcftools norm -m -any -o ${bcf_file.simpleName}_norm_int.vcf -f ${ref} ${bcf_file}
+	bcftools norm -m -any -Oz -o ${bcf_file.simpleName}_norm_int.vcf -f ${ref} ${bcf_file}
 	bcftools annotate --set-id '%CHROM\\_%POS\\_%REF\\_%FIRST_ALT' -O z -o ${bcf_file.simpleName}_norm.vcf.gz ${bcf_file.simpleName}_norm_int.vcf
 	"""
 }

--- a/modules/bcf_to_vcf.nf
+++ b/modules/bcf_to_vcf.nf
@@ -18,14 +18,20 @@ process bcf_to_vcf {
 	val assembly
 	val batch
 	val run
+	file ref
 
 	output :
-	path '*.vcf.gz', emit : vcf	
+	path '*_norm.vcf.gz', emit : vcf	
+	path '*GLnexus_output.vcf.gz'
 
 	script :
 	"""
-##	bcftools view ${bcf_file} | bgzip -c > ${bcf_file.simpleName}.vcf.gz
-	bcftools norm -m -any -o ${bcf_file.simpleName}_norm.vcf ${bcf_file}
-	bcftools annotate --set-id '%CHROM\\_%POS\\_%REF\\_%FIRST_ALT' -O z -o ${bcf_file.simpleName}.vcf.gz ${bcf_file.simpleName}_norm.vcf
+	# output an unmodified population vcf in compressed format
+	bcftools view ${bcf_file} -Oz -o ${bcf_file.simpleName}_GLnexus_output.vcf.gz
+	bcftools index -t ${bcf_file.simpleName}_GLnexus_output.vcf.gz
+
+	# normalize/left align and split multi-allelic variants 
+	bcftools norm -m -any -o ${bcf_file.simpleName}_norm_int.vcf -f ${ref} ${bcf_file}
+	bcftools annotate --set-id '%CHROM\\_%POS\\_%REF\\_%FIRST_ALT' -O z -o ${bcf_file.simpleName}_norm.vcf.gz ${bcf_file.simpleName}_norm_int.vcf
 	"""
 }

--- a/modules/bcf_to_vcf.nf
+++ b/modules/bcf_to_vcf.nf
@@ -31,7 +31,8 @@ process bcf_to_vcf {
 	bcftools index -t ${bcf_file.simpleName}_GLnexus_output.vcf.gz
 
 	# normalize/left align and split multi-allelic variants 
-	bcftools norm -m -any -Oz -o ${bcf_file.simpleName}_norm_int.vcf -f ${ref} ${bcf_file}
-	bcftools annotate --set-id '%CHROM\\_%POS\\_%REF\\_%FIRST_ALT' -O z -o ${bcf_file.simpleName}_norm.vcf.gz ${bcf_file.simpleName}_norm_int.vcf
+	bcftools norm -m -any -Oz -o ${bcf_file.simpleName}_norm_int.vcf.gz -f ${ref} ${bcf_file}
+	bcftools index -t  ${bcf_file.simpleName}_norm_int.vcf.gz
+	bcftools annotate --set-id '%CHROM\\_%POS\\_%REF\\_%FIRST_ALT' -O z -o ${bcf_file.simpleName}_norm.vcf.gz ${bcf_file.simpleName}_norm_int.vcf.gz
 	"""
 }

--- a/nextflow.config
+++ b/nextflow.config
@@ -27,9 +27,10 @@ params {
     outdir_pop              = "/mnt/scratch/SILENT/Act3/Processed/Population/"
 	tmp_dir					= "/mnt/scratch/SILENT/Act3/Processed/Individual//tmp"
 
-//SAMPLE FILTERING:
-        params.filter_samples                                  = false
-        params.filter_list                              = "" 
+//SAMPLE FILTERING: the filter list must be a tab-separated file, with a single column (id 's') with 
+//the IDs of the samples to be filtered
+        params.filter_samples   = false
+        params.filter_list      = "" 
                                                         
 //Constants
 	SNV						= "SNV"

--- a/nextflow.config
+++ b/nextflow.config
@@ -27,7 +27,11 @@ params {
     outdir_pop              = "/mnt/scratch/SILENT/Act3/Processed/Population/Kiana_Pipeline_Dev_Summer24/"
 	tmp_dir					= "/mnt/scratch/SILENT/Act3/Processed/Individual/Kiana_Pipeline_Dev_Summer24/tmp"
 
-	//Constant
+//SAMPLE FILTERING:
+        filter_samples                                  = False
+        params.filter_list                              = "" 
+                                                        
+//Constants
 	SNV						= "SNV"
 	STR						= "STR"
 	MEI						= "MEI"

--- a/nextflow.config
+++ b/nextflow.config
@@ -9,7 +9,7 @@ env {
 	//NXF_TEMP = "/mnt/scratch/SILENT/Act3/Processed/Individual/tmp/"
 }
 
-launchDir	= "/mnt/scratch/SILENT/Act3/Processed/Workflow/Kiana_Pipeline_Dev_Summer24/Variant_catalogue_pipeline/"
+launchDir	= "/mnt/scratch/SILENT/Act3/Processed/Workflow//Variant_catalogue_pipeline/"
 ReferenceDir	= "/mnt/common/SILENT/Act3/"
 SingularityDir	= "/mnt/common/SILENT/Act3/singularity/"
 workdir = "/mnt/scratch/SILENT/Act3/Processed/Individual/"
@@ -19,10 +19,10 @@ workdir = "/mnt/scratch/SILENT/Act3/Processed/Individual/"
 //GLI2 = "/mnt/scratch/SILENT/Act3/Processed/Individual/Real_Data_2023/"
 
 params {
-	run             		= "Run_20240619_Version_0.0.2"
-	batch           		= "Batch_test_2024_06_19"
-//  reads            		= "/mnt/scratch/SILENT/Act3/Test_Data_Platinum_Genomes/reads/*{1,2}.fastq.gz"
-	sample_sheet   			= "/mnt/scratch/SILENT/Act3/Real_Data_Processing/sample_sheets/platinum_sheets/platinum_sheet_batch_01.csv"
+	run             		= ""
+	batch           		= ""
+    reads            		= ""
+	sample_sheet   			= ""
     outdir_ind              = "/mnt/scratch/SILENT/Act3/Processed/Individual/"
     outdir_pop              = "/mnt/scratch/SILENT/Act3/Processed/Population/"
 	tmp_dir					= "/mnt/scratch/SILENT/Act3/Processed/Individual//tmp"

--- a/nextflow.config
+++ b/nextflow.config
@@ -149,7 +149,7 @@ profiles {
 
                 //tsv files containing reduced information from gnomAD largest file - code to generate the tsv files available in the GitHub repo of pipeline
                 //This file is not necessary to obtain the vcf with variant frequencies and annotation
-                params.gnomad_SNV_frequ                 = '/mnt/common/SILENT/Act3/GRCh38/gnomad_v4/*.tsv'
+                params.gnomad_SNV_frequ                 = '/mnt/common/SILENT/Act3/GRCh38/gnomad_v4.1_joint/tables/*.tsv'
 
 		// If you haven't generated the above files, then you need to run the Initiatlisation.nf submodule, which requires the gnomad_SNV_vcf and gnomad_SNV_vcf_index files below
 		params.gnomad_SNV_vcf			= '/mnt/common/DATABASES/REFERENCES/GRCh38/GNOMAD/V3/gnomad.genomes.r3.0.sites.vcf.gz'

--- a/nextflow.config
+++ b/nextflow.config
@@ -12,7 +12,7 @@ env {
 launchDir	= "/mnt/scratch/SILENT/Act3/Processed/Workflow/Kiana_Pipeline_Dev_Summer24/Variant_catalogue_pipeline/"
 ReferenceDir	= "/mnt/common/SILENT/Act3/"
 SingularityDir	= "/mnt/common/SILENT/Act3/singularity/"
-workdir = "/mnt/scratch/SILENT/Act3/Processed/Individual/Kiana_Pipeline_Dev_Summer24"
+workdir = "/mnt/scratch/SILENT/Act3/Processed/Individual/"
 
 //seem redundant - will remove after test run (now workdir is bound to Singularity instead)
 //GLI = "/mnt/scratch/SILENT/Act3/Processed/Individual/Real_Data_2023/"
@@ -23,12 +23,12 @@ params {
 	batch           		= "Batch_test_2024_06_19"
 //  reads            		= "/mnt/scratch/SILENT/Act3/Test_Data_Platinum_Genomes/reads/*{1,2}.fastq.gz"
 	sample_sheet   			= "/mnt/scratch/SILENT/Act3/Real_Data_Processing/sample_sheets/platinum_sheets/platinum_sheet_batch_01.csv"
-    outdir_ind              = "/mnt/scratch/SILENT/Act3/Processed/Individual/Kiana_Pipeline_Dev_Summer24/"
-    outdir_pop              = "/mnt/scratch/SILENT/Act3/Processed/Population/Kiana_Pipeline_Dev_Summer24/"
-	tmp_dir					= "/mnt/scratch/SILENT/Act3/Processed/Individual/Kiana_Pipeline_Dev_Summer24/tmp"
+    outdir_ind              = "/mnt/scratch/SILENT/Act3/Processed/Individual/"
+    outdir_pop              = "/mnt/scratch/SILENT/Act3/Processed/Population/"
+	tmp_dir					= "/mnt/scratch/SILENT/Act3/Processed/Individual//tmp"
 
 //SAMPLE FILTERING:
-        filter_samples                                  = False
+        params.filter_samples                                  = false
         params.filter_list                              = "" 
                                                         
 //Constants

--- a/subworkflow/SNV.nf
+++ b/subworkflow/SNV.nf
@@ -65,7 +65,7 @@ workflow SNV {
 
                 Hail_sample_QC(bcf_to_vcf.out.vcf, assembly,reference,reference_index,batch,run)
                 Hail_variant_QC(Hail_sample_QC.out.vcf_sample_filtered, Hail_sample_QC.out.filtered_sample_sex, assembly, reference, reference_index,batch,run,var_qc_intervals)
-                SNV_annotation_table_merged(Hail_variant_QC.out.vcf_SNV_filtered_frequ_only, Hail_variant_QC.out.index_SNV_filtered_frequ_only, vep_cache_merged, vep_cache_merged_version, assembly, run, assembly, CADD_1_6_whole_genome_SNVs, CADD_1_6_whole_genome_SNVs_index, CADD_1_6_InDels, CADD_1_6_InDels_index, spliceai_snv, spliceai_snv_index, spliceai_indel, spliceai_indel_index, SNV, reference, dir_plugin)
+                SNV_annotation_table_merged(Hail_variant_QC.out.vcf_SNV_filtered_frequ_only.flatten(), vep_cache_merged, vep_cache_merged_version, assembly, run, assembly, CADD_1_6_whole_genome_SNVs, CADD_1_6_whole_genome_SNVs_index, CADD_1_6_InDels, CADD_1_6_InDels_index, spliceai_snv, spliceai_snv_index, spliceai_indel, spliceai_indel_index, SNV, reference, dir_plugin)
 
 		SNV_data_organization(gnomad_SNV_frequ, SNV_annotation_table_merged.out.annotation_vcf, assembly, run, severity_table)
 

--- a/subworkflow/SNV.nf
+++ b/subworkflow/SNV.nf
@@ -33,7 +33,7 @@ workflow SNV {
 	reference       			= file (params.ref)
 	reference_index 			= file (params.ref_index)
         SNV                                     = params.SNV
-
+		var_qc_intervals 						= ['autosomal', 'X', 'Y']
         chr                                     = params.chrom
         vep_cache_merged                        = file (params.vep_cache_merged)
         vep_cache_merged_version                = params.vep_cache_merged_version
@@ -61,10 +61,10 @@ workflow SNV {
 		// Aggregated steps (Need to be run everytime a new sample is added to the cohort)
 		list_vcfs_txt(deepvariant_call.out.deepvariant_gvcf.collect(), assembly, batch, run, SNV)
 		GLnexus_cli(list_vcfs_txt.out, run)
-		bcf_to_vcf(GLnexus_cli.out, assembly, batch, run)
+		bcf_to_vcf(GLnexus_cli.out, assembly, batch, run, reference)
 
                 Hail_sample_QC(bcf_to_vcf.out.vcf, assembly,reference,reference_index,batch,run)
-                Hail_variant_QC(Hail_sample_QC.out.vcf_sample_filtered, Hail_sample_QC.out.filtered_sample_sex, assembly, reference, reference_index,batch,run,chr)
+                Hail_variant_QC(Hail_sample_QC.out.vcf_sample_filtered, Hail_sample_QC.out.filtered_sample_sex, assembly, reference, reference_index,batch,run,var_qc_intervals)
                 SNV_annotation_table_merged(Hail_variant_QC.out.vcf_SNV_filtered_frequ_only, Hail_variant_QC.out.index_SNV_filtered_frequ_only, vep_cache_merged, vep_cache_merged_version, assembly, run, assembly, CADD_1_6_whole_genome_SNVs, CADD_1_6_whole_genome_SNVs_index, CADD_1_6_InDels, CADD_1_6_InDels_index, spliceai_snv, spliceai_snv_index, spliceai_indel, spliceai_indel_index, SNV, reference, dir_plugin)
 
 		SNV_data_organization(gnomad_SNV_frequ, SNV_annotation_table_merged.out.annotation_vcf, assembly, run, severity_table)


### PR DESCRIPTION
- QC updates : hail sample QC and hail variant QC are updated to no longer automatically filter off of somewhat arbitrary standard deviations, and to flag outliers instead. Variant QC updated to:
  -  filter for "AC0" at the site level - see documentation in code
  - remove calls on the Y chromosome for XX samples
  - filter large indels (>50bp)
  - filter variants with an allele count of 0 (due to samples being filtered)
- a new run option for filtering samples with a sample list is introduced
- there are some fixes to the annotation script
- a vcf file for filtered large indels (>50bp) is now produced (pre-QC)
- a vcf file, post-QC, for autosomal chromosomes is produced, in addition to the vcfs created for each chromosome (chr1-22, X, Y)
- additional files are published (QC outputs, raw output from GLNexus (bcf), compressed vcf of un-normalized population callset, some additional plots)
- gnomad (for GRCh38 assembly) updated to V4.1, and to include filter columns in final tables
